### PR TITLE
Illuminate packages 8.x is supported now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,15 +24,6 @@ jobs: # Docs: <https://git.io/JvxXE>
         include:
           - php: '7.3'
             setup: basic
-            illuminate: '~5.7.0'
-          - php: '7.3'
-            setup: basic
-            illuminate: '~5.8.0'
-          - php: '7.3'
-            setup: basic
-            illuminate: '~6.0'
-          - php: '7.3'
-            setup: basic
             illuminate: '~7.0'
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '7.3'
             setup: basic
             illuminate: '~6.0'
+          - php: '7.3'
+            setup: basic
+            illuminate: '~7.0'
 
     steps:
       - name: Check out code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.1.0
+
+### Changed
+
+- Dependency `illuminate/support` version `~8.0` is supported now
+- Minimal `illuminate/support` version now is `6.0`
+- Dependency `tarampampam/wrappers-php` version `~2.0` is supported now
+
 ## v1.0.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Dependency `illuminate/support` version `~8.0` is supported now
-- Minimal `illuminate/support` version now is `6.0`
+- Minimal required `illuminate/support` version now is `6.0` (instead `^5.6`)
 - Dependency `tarampampam/wrappers-php` version `~2.0` is supported now
 
 ## v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.2.5-alpine
+FROM php:7.3.5-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
 SHELL = /bin/sh
-RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
+RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)"
 
 .PHONY : help build install lowest test test-cover shell clean
 .DEFAULT_GOAL : help
@@ -16,20 +16,23 @@ help: ## Show this help
 build: ## Build docker images, required for current package environment
 	docker-compose build
 
+latest: clean ## Install latest php dependencies
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+
 install: clean ## Install regular php dependencies
-	docker-compose run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
 
 lowest: clean ## Install lowest php dependencies
-	docker-compose run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
-	docker-compose run $(RUN_APP_ARGS) composer test
+	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
 	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	docker-compose run $(RUN_APP_ARGS) sh
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "avtocod/specs": "~3.46",
-        "illuminate/support": "^5.6 || ~6.0 || ~7.0",
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
         "ocramius/package-versions": "^1.4",
-        "tarampampam/wrappers-php": "^1.5"
+        "tarampampam/wrappers-php": "^1.5 || ~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5",
+        "phpunit/phpunit": "~7.5 || ^8.0",
         "phpstan/phpstan": "~0.12"
     },
     "autoload": {


### PR DESCRIPTION
## Description

### Changed

- Dependency `illuminate/support` version `~8.0` is supported now
- Minimal `illuminate/support` version now is `6.0`
- Dependency `tarampampam/wrappers-php` version `~2.0` is supported now

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
