### PR TITLE
Remove tarampampam/wrappers-php

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs: # Docs: <https://git.io/JvxXE>
       matrix:
         setup: ['basic', 'lowest']
         illuminate: [default]
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.3', '7.4']
         include:
           - php: '7.3'
             setup: basic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Minimal required PHP version now is `7.3`
+
+### Removed
+
+- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed
+
 ## v1.3.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Removed
 
-- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed
+- Dependency `tarampampam/wrappers-php`
 
 ## v1.3.0
 

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-json": "*",
         "ext-mbstring": "*",
         "avtocod/specs": "~3.70",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0",
-        "ocramius/package-versions": "^1.4",
-        "tarampampam/wrappers-php": "^1.5 || ~2.0"
+        "ocramius/package-versions": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.5 || ^8.0",

--- a/src/Specifications.php
+++ b/src/Specifications.php
@@ -7,7 +7,6 @@ namespace Avtocod\Specifications;
 use Exception;
 use InvalidArgumentException;
 use PackageVersions\Versions;
-use Tarampampam\Wrappers\Json;
 use Illuminate\Support\Collection;
 use Avtocod\Specifications\Structures\Field;
 use Avtocod\Specifications\Structures\Source;
@@ -18,7 +17,6 @@ use Avtocod\Specifications\Structures\IdentifierType;
 use Avtocod\Specifications\Structures\VehicleBodyType;
 use Avtocod\Specifications\Structures\VehicleEngineType;
 use Avtocod\Specifications\Structures\VehicleTransmissionType;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 use Avtocod\Specifications\Structures\VehicleDrivingWheelsType;
 use Avtocod\Specifications\Structures\VehicleSteeringWheelType;
 
@@ -473,7 +471,7 @@ class Specifications
      * @param bool   $as_array
      *
      * @throws InvalidArgumentException
-     * @throws JsonEncodeDecodeException
+     * @throws \JsonException
      *
      * @return object|mixed[]
      */
@@ -486,8 +484,8 @@ class Specifications
         $content = (string) \file_get_contents($file_path);
 
         return $as_array === true
-            ? (array) Json::decode($content, true)
-            : (object) Json::decode($content, false);
+            ? (array) \json_decode($content, true, 512, JSON_THROW_ON_ERROR)
+            : (object) \json_decode($content, false, 512, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/Structures/AbstractStructure.php
+++ b/src/Structures/AbstractStructure.php
@@ -6,10 +6,8 @@ namespace Avtocod\Specifications\Structures;
 
 use ArrayIterator;
 use LogicException;
-use Tarampampam\Wrappers\Json;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 /**
  * @implements \ArrayAccess<string,mixed>
@@ -30,13 +28,13 @@ abstract class AbstractStructure implements Arrayable, Jsonable, \ArrayAccess, \
     /**
      * {@inheritdoc}
      *
-     * @throws JsonEncodeDecodeException
+     * @throws \JsonException
      *
      * @deprecated Will be removed in closest major release
      */
     public function toJson($options = 0): string
     {
-        return Json::encode($this->toArray(), $options);
+        return (string) \json_encode($this->toArray(), JSON_THROW_ON_ERROR | $options);
     }
 
     /**

--- a/tests/SpecificationsTest.php
+++ b/tests/SpecificationsTest.php
@@ -9,7 +9,6 @@ use ReflectionClass;
 use ReflectionMethod;
 use InvalidArgumentException;
 use PackageVersions\Versions;
-use Tarampampam\Wrappers\Json;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Avtocod\Specifications\Specifications;
@@ -84,11 +83,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(Field::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/fields/default/fields_list.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/fields/default/fields_list.json'
+            )), true);
 
             $this->assertCount(\count($raw), $result);
 
@@ -128,11 +125,9 @@ class SpecificationsTest extends TestCase
                 $result = $this->instance::getReportExample($group_name, $name);
                 $this->assertIsArray($result);
 
-                $raw = Json::decode(
-                    \file_get_contents($this->instance::getRootDirectoryPath(
-                        "/reports/default/examples/{$name}.json"
-                    ))
-                );
+                $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                    "/reports/default/examples/{$name}.json"
+                )), true);
 
                 $this->assertSame($result, $raw);
             }
@@ -174,11 +169,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(IdentifierType::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/identifiers/default/types_list.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/identifiers/default/types_list.json'
+            )), true);
 
             $this->assertCount(\count($raw), $result);
 
@@ -252,11 +245,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(Source::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/sources/default/sources_list.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/sources/default/sources_list.json'
+            )), true);
 
             $this->assertCount(\count($raw), $result);
 
@@ -293,11 +284,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleMark::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/marks.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/marks.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 
@@ -323,11 +312,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleModel::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/models.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/models.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 
@@ -358,8 +345,8 @@ class SpecificationsTest extends TestCase
                 } else {
                     $path_file = sprintf('/vehicles/default/models_%s.json', $alias);
                 }
-                $raw       = Json::decode(
-                    \file_get_contents($this->instance::getRootDirectoryPath($path_file))
+                $raw       = \json_decode(
+                    \file_get_contents($this->instance::getRootDirectoryPath($path_file)), true
                 );
                 $this->assertCount(count($raw), $result);
 
@@ -386,11 +373,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleBodyType::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/body_types.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/body_types.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 
@@ -416,11 +401,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleDrivingWheelsType::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/driving_wheels_types.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/driving_wheels_types.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 
@@ -446,11 +429,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleEngineType::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/engine_types.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/engine_types.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 
@@ -476,11 +457,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleSteeringWheelType::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/steering_wheel_types.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/steering_wheel_types.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 
@@ -506,11 +485,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleTransmissionType::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/transmission_types.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/transmission_types.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 
@@ -599,11 +576,9 @@ class SpecificationsTest extends TestCase
                 $this->assertInstanceOf(VehicleType::class, $item);
             }
 
-            $raw = Json::decode(
-                \file_get_contents($this->instance::getRootDirectoryPath(
-                    '/vehicles/default/types.json'
-                ))
-            );
+            $raw = \json_decode(\file_get_contents($this->instance::getRootDirectoryPath(
+                '/vehicles/default/types.json'
+            )), true);
 
             $this->assertCount(count($raw), $result);
 


### PR DESCRIPTION
## Description

### Changed

- Minimal required PHP version now is `7.3`

### Removed

- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
