### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,15 +20,10 @@ jobs: # Docs: <https://git.io/JvxXE>
       matrix:
         setup: ['basic', 'lowest']
         illuminate: [default]
-        php: ['7.3', '7.4', '8.0']
-        include:
-          - php: '7.4'
-            setup: basic
-            illuminate: '~7.0'
-
+        php: ['8.0','8.1','8.2','8.3']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -39,12 +34,12 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -66,7 +61,7 @@ jobs: # Docs: <https://git.io/JvxXE>
       - name: Execute tests
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/clover.xml
@@ -77,7 +72,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Minimal PHP version now is `8.0.2`
 - Minimal Laravel version now is `9.0`
-- Minimal `phpstan/phpstan` version now is `1.10`
 - Minimal `phpunit/phpunit` version now is `9.6`
+- Minimal `phpstan/phpstan` version now is `1.10`
 - Version of `composer` in docker container updated up to `2.6.6`
 
 ## v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- `Laravel 10` support
+- `PHP Unit 10` support
+
+### Changed
+
+- Minimal PHP version now is `8.0.2`
+- Minimal Laravel version now is `9.0`
+- Minimal `phpstan/phpstan` version now is `1.10`
+- Minimal `phpunit/phpunit` version now is `9.6`
+- Version of `composer` in docker container updated up to `2.6.6`
+
 ## v1.7.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM php:8.0-alpine
+FROM php:8.1-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.3.5 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6.6 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
-    && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
+    && apk add --no-cache --virtual .build-deps autoconf linux-headers pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but not enable it
-    && pecl install xdebug-3.1.4 1>/dev/null \
+    && pecl install xdebug-3.3.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: ## Execute php tests and linters
 	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
 	docker-compose run $(RUN_APP_ARGS) app sh

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0.2",
         "ext-json": "*",
         "ext-mbstring": "*",
         "avtocod/specs": "~3.70",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0"
+        "illuminate/support": "~9.0 || ~10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
-        "phpstan/phpstan": "0.12.99"
+        "phpunit/phpunit": "^9.6 || ^10.0",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Structures/AbstractStructure.php
+++ b/src/Structures/AbstractStructure.php
@@ -10,6 +10,8 @@ use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
+ * @template AbstractStructureData of array<string, mixed>
+ *
  * @implements \ArrayAccess<string,mixed>
  * @implements \IteratorAggregate<string,mixed>
  */
@@ -18,7 +20,7 @@ abstract class AbstractStructure implements Arrayable, Jsonable, \ArrayAccess, \
     /**
      * Create a new structure instance.
      *
-     * @param mixed|null $raw_data
+     * @param AbstractStructureData|null $raw_data
      */
     public function __construct($raw_data = null)
     {
@@ -50,7 +52,7 @@ abstract class AbstractStructure implements Arrayable, Jsonable, \ArrayAccess, \
     /**
      * Whether a offset exists.
      *
-     * @param mixed $offset
+     * @param string $offset
      *
      * @return bool
      */
@@ -60,42 +62,29 @@ abstract class AbstractStructure implements Arrayable, Jsonable, \ArrayAccess, \
     }
 
     /**
-     * Offset to retrieve.
-     *
-     * @param mixed $offset
-     *
-     * @return mixed
+     * @inheritdoc
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->{$offset};
     }
 
     /**
-     * Offset to set.
+     * @inheritdoc
      *
-     * @param mixed $offset
-     * @param mixed $value
-     *
-     * @throws LogicException
-     *
-     * @return void
+     *  @throws LogicException
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new LogicException('Changing are not allowed');
     }
 
     /**
-     * Offset to unset.
+     * @inheritdoc
      *
-     * @param mixed $offset
-     *
-     * @throws LogicException
-     *
-     * @return void
+     *  @throws LogicException
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new LogicException('Changing are not allowed');
     }
@@ -103,11 +92,11 @@ abstract class AbstractStructure implements Arrayable, Jsonable, \ArrayAccess, \
     /**
      * Configure itself.
      *
-     * @param mixed[]|iterable $raw_data
+     * @param AbstractStructureData|null $raw_data
      *
      * @return void
      *
-     * @deprecated Will be removed in closest major release
+     * @deprecated Will be removed in the closest major release
      */
     abstract protected function configure($raw_data);
 }

--- a/src/Structures/Field.php
+++ b/src/Structures/Field.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type FieldData array{path:string|null, description:string|null, types:string[]|null, fillable_by:string[]|null}
+ *
+ * @extends AbstractStructure<FieldData>
+ */
 class Field extends AbstractStructure
 {
     /**
@@ -40,7 +45,7 @@ class Field extends AbstractStructure
     /**
      * Possible sources.
      *
-     * @var string[]|array
+     * @var string[]|null
      */
     protected $fillable_by;
 
@@ -154,7 +159,6 @@ class Field extends AbstractStructure
                         break;
 
                     case 'types':
-                        /* @var string[]|null $value */
                         $value === null
                             ? null
                             : \array_filter((array) $value, '\is_string');
@@ -163,7 +167,6 @@ class Field extends AbstractStructure
                         break;
 
                     case 'fillable_by':
-                        /* @var string[]|null $value */
                         $value === null
                             ? null
                             : \array_filter((array) $value, '\is_string');

--- a/src/Structures/IdentifierType.php
+++ b/src/Structures/IdentifierType.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type IdentifierTypeData array{type:string|null, description:string|null}
+ *
+ * @extends AbstractStructure<IdentifierTypeData>
+ */
 class IdentifierType extends AbstractStructure
 {
     /**

--- a/src/Structures/Source.php
+++ b/src/Structures/Source.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type SourceData array{name:string|null, description:string|null}
+ *
+ * @extends AbstractStructure<SourceData>
+ */
 class Source extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleBodyType.php
+++ b/src/Structures/VehicleBodyType.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleBodyTypeData array{name:string|null, id:string|null}
+ *
+ * @extends AbstractStructure<VehicleBodyTypeData>
+ */
 class VehicleBodyType extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleDrivingWheelsType.php
+++ b/src/Structures/VehicleDrivingWheelsType.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleDrivingWheelsTypeData array{name:string|null, id:string|null}
+ *
+ * @extends AbstractStructure<VehicleDrivingWheelsTypeData>
+ */
 class VehicleDrivingWheelsType extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleEngineType.php
+++ b/src/Structures/VehicleEngineType.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleEngineTypeData array{name:string|null, id:string|null}
+ *
+ * @extends AbstractStructure<VehicleEngineTypeData>
+ */
 class VehicleEngineType extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleMark.php
+++ b/src/Structures/VehicleMark.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleMarkData array{name:string|null, id:string|null}
+ *
+ * @extends AbstractStructure<VehicleMarkData>
+ */
 class VehicleMark extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleModel.php
+++ b/src/Structures/VehicleModel.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleModelData array{name:string|null, id:string|null, mark_id:string|null}
+ *
+ * @extends AbstractStructure<VehicleModelData>
+ */
 class VehicleModel extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleSteeringWheelType.php
+++ b/src/Structures/VehicleSteeringWheelType.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleSteeringWheelTypeData array{name:string|null, id:string|null}
+ *
+ * @extends AbstractStructure<VehicleSteeringWheelTypeData>
+ */
 class VehicleSteeringWheelType extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleTransmissionType.php
+++ b/src/Structures/VehicleTransmissionType.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleTransmissionTypeData array{name:string|null, id:string|null}
+ *
+ * @extends AbstractStructure<VehicleTransmissionTypeData>
+ */
 class VehicleTransmissionType extends AbstractStructure
 {
     /**

--- a/src/Structures/VehicleType.php
+++ b/src/Structures/VehicleType.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Avtocod\Specifications\Structures;
 
+/**
+ * @phpstan-type VehicleTypeData array{name:string|null, id:string|null, alias:string|null}
+ *
+ * @extends AbstractStructure<VehicleTypeData>
+ */
 class VehicleType extends AbstractStructure
 {
     /**

--- a/tests/SpecificationsTest.php
+++ b/tests/SpecificationsTest.php
@@ -25,7 +25,7 @@ use Avtocod\Specifications\Structures\VehicleDrivingWheelsType;
 use Avtocod\Specifications\Structures\VehicleSteeringWheelType;
 
 /**
- * @covers \Avtocod\Specifications\Specifications<extended>
+ * @covers \Avtocod\Specifications\Specifications
  */
 class SpecificationsTest extends TestCase
 {

--- a/tests/Structures/FieldTest.php
+++ b/tests/Structures/FieldTest.php
@@ -5,7 +5,7 @@ namespace Avtocod\Specifications\Tests\Structures;
 use Avtocod\Specifications\Structures\Field;
 
 /**
- * @covers \Avtocod\Specifications\Structures\Field<extended>
+ * @covers \Avtocod\Specifications\Structures\Field
  */
 class FieldTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/IdentifierTypeTest.php
+++ b/tests/Structures/IdentifierTypeTest.php
@@ -5,7 +5,7 @@ namespace Avtocod\Specifications\Tests\Structures;
 use Avtocod\Specifications\Structures\IdentifierType;
 
 /**
- * @covers \Avtocod\Specifications\Structures\IdentifierType<extended>
+ * @covers \Avtocod\Specifications\Structures\IdentifierType
  */
 class IdentifierTypeTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/SourceTest.php
+++ b/tests/Structures/SourceTest.php
@@ -5,7 +5,7 @@ namespace Avtocod\Specifications\Tests\Structures;
 use Avtocod\Specifications\Structures\Source;
 
 /**
- * @covers \Avtocod\Specifications\Structures\Source<extended>
+ * @covers \Avtocod\Specifications\Structures\Source
  */
 class SourceTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleBodyTypeTest.php
+++ b/tests/Structures/VehicleBodyTypeTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 use Avtocod\Specifications\Structures\VehicleBodyType;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleBodyType<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleBodyType
  */
 class VehicleBodyTypeTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleDrivingWheelsTypeTest.php
+++ b/tests/Structures/VehicleDrivingWheelsTypeTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 use Avtocod\Specifications\Structures\VehicleDrivingWheelsType;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleDrivingWheelsType<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleDrivingWheelsType
  */
 class VehicleDrivingWheelsTypeTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleEngineTypeTest.php
+++ b/tests/Structures/VehicleEngineTypeTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 use Avtocod\Specifications\Structures\VehicleEngineType;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleEngineType<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleEngineType
  */
 class VehicleEngineTypeTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleMarkTest.php
+++ b/tests/Structures/VehicleMarkTest.php
@@ -5,7 +5,7 @@ namespace Avtocod\Specifications\Tests\Structures;
 use Avtocod\Specifications\Structures\VehicleMark;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleMark<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleMark
  */
 class VehicleMarkTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleModelTest.php
+++ b/tests/Structures/VehicleModelTest.php
@@ -5,7 +5,7 @@ namespace Avtocod\Specifications\Tests\Structures;
 use Avtocod\Specifications\Structures\VehicleModel;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleModel<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleModel
  */
 class VehicleModelTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleSteeringWheelTypeTest.php
+++ b/tests/Structures/VehicleSteeringWheelTypeTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 use Avtocod\Specifications\Structures\VehicleSteeringWheelType;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleSteeringWheelType<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleSteeringWheelType
  */
 class VehicleSteeringWheelTypeTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleTransmissionTypeTest.php
+++ b/tests/Structures/VehicleTransmissionTypeTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
 use Avtocod\Specifications\Structures\VehicleTransmissionType;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleTransmissionType<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleTransmissionType
  */
 class VehicleTransmissionTypeTest extends AbstractStructureTestCase
 {

--- a/tests/Structures/VehicleTypeTest.php
+++ b/tests/Structures/VehicleTypeTest.php
@@ -5,7 +5,7 @@ namespace Avtocod\Specifications\Tests\Structures;
 use Avtocod\Specifications\Structures\VehicleType;
 
 /**
- * @covers \Avtocod\Specifications\Structures\VehicleType<extended>
+ * @covers \Avtocod\Specifications\Structures\VehicleType
  */
 class VehicleTypeTest extends AbstractStructureTestCase
 {


### PR DESCRIPTION
## Description

- Laravel 10 
- PHPUnit 10 Support

Closes #15 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Added

- `Laravel 10` support
- `PHP Unit 10` support

### Changed

- Minimal PHP version now is `8.0.2`
- Minimal Laravel version now is `9.0`
- Minimal `phpstan/phpstan` version now is `1.10`
- Minimal `phpunit/phpunit` version now is `9.6`
- Version of `composer` in docker container updated up to `2.6.6`
