### PR TITLE
update specs version to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal `avtocod/specs` version now is `5.0`
+
 ## v1.11.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0.2",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "avtocod/specs": "~4.0",
+        "avtocod/specs": "~5.0",
         "illuminate/support": "~9.0 || ~10.0 || ~11.0 || ~12.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Description

### Changed

- Minimal `avtocod/specs` version now is `5.0`